### PR TITLE
Customizable `enforceContactAndJointAndCustomConstraints` function

### DIFF
--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -538,7 +538,7 @@ std::vector<s_t*> BoxedLcpConstraintSolver::solveLcp(
   // leads to numerical instability during the backwards pass.
   if (!success)
   {
-    cfm = mFallbackConstraintForceMixingConstant();
+    cfm = mFallbackConstraintForceMixingConstant;
     // Apply the constraint force mixing
     mABackup.diagonal()
         += Eigen::VectorXs::Ones(mABackup.diagonal().size()) * cfm;

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -350,7 +350,7 @@ LcpInputs BoxedLcpConstraintSolver::buildLcpInputs(ConstrainedGroup& group)
 
 //==============================================================================
 std::vector<s_t*> BoxedLcpConstraintSolver::solveLcp(
-    LcpInputs lcpInputs, ConstrainedGroup& group, simulation::World* world)
+    LcpInputs lcpInputs, ConstrainedGroup& group)
 {
   const std::size_t numConstraints = group.getNumConstraints();
   const std::size_t n = group.getTotalDimension();
@@ -445,7 +445,7 @@ std::vector<s_t*> BoxedLcpConstraintSolver::solveLcp(
         aGradientBackup,
         cfm,
         false);
-    grads->constructMatrices(world);
+    grads->constructMatrices();
     success = grads->areResultsStandardized();
     // If this worked, we don't need to reconstruct our constraint matrices,
     // since the ones we just made already work by construction
@@ -538,7 +538,7 @@ std::vector<s_t*> BoxedLcpConstraintSolver::solveLcp(
   // leads to numerical instability during the backwards pass.
   if (!success)
   {
-    cfm = world->getFallbackConstraintForceMixingConstant();
+    cfm = mFallbackConstraintForceMixingConstant();
     // Apply the constraint force mixing
     mABackup.diagonal()
         += Eigen::VectorXs::Ones(mABackup.diagonal().size()) * cfm;
@@ -727,7 +727,7 @@ std::vector<s_t*> BoxedLcpConstraintSolver::solveLcp(
         aGradientBackup,
         cfm,
         hadToIgnoreFrictionToSolve);
-    group.getGradientConstraintMatrices()->constructMatrices(world);
+    group.getGradientConstraintMatrices()->constructMatrices();
     if (group.getGradientConstraintMatrices()->areResultsStandardized())
     {
       mX = group.getGradientConstraintMatrices()
@@ -790,10 +790,10 @@ std::vector<s_t*> BoxedLcpConstraintSolver::solveLcp(
 
 //==============================================================================
 std::vector<s_t*> BoxedLcpConstraintSolver::solveConstrainedGroup(
-    ConstrainedGroup& group, simulation::World* world)
+    ConstrainedGroup& group)
 {
   LcpInputs lcpInputs = buildLcpInputs(group);
-  return solveLcp(lcpInputs, group, world);
+  return solveLcp(lcpInputs, group);
 }
 
 //==============================================================================

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -114,15 +114,13 @@ public:
   virtual void setCachedLCPSolution(Eigen::VectorXs X) override;
 
   // Documentation inherited.
-  std::vector<s_t*> solveConstrainedGroup(
-      ConstrainedGroup& group, simulation::World* world) override;
+  std::vector<s_t*> solveConstrainedGroup(ConstrainedGroup& group) override;
 
   /// Build the inputs to the LCP from the constraint group.
   LcpInputs buildLcpInputs(ConstrainedGroup& group);
 
   /// Setup and solve an LCP to enforce the constraints on the ConstrainedGroup.
-  std::vector<s_t*> solveLcp(
-      LcpInputs lcpInputs, ConstrainedGroup& group, simulation::World* world);
+  std::vector<s_t*> solveLcp(LcpInputs lcpInputs, ConstrainedGroup& group);
 
 protected:
   /// Boxed LCP solver

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -88,8 +88,7 @@ ConstraintSolver::ConstraintSolver()
                 // gradients
     mContactClippingDepth(
         0.03), // Default to clipping only after fairly deep penetration
-    mSolveCallback(
-        [this](simulation::World* world) { return lcpSolveCallback(world); })
+    mSolveCallback([this]() { return lcpSolveCallback(); })
 {
 }
 
@@ -441,6 +440,12 @@ void ConstraintSolver::setPenetrationCorrectionEnabled(bool enable)
 bool ConstraintSolver::getPenetrationCorrectionEnabled()
 {
   return mPenetrationCorrectionEnabled;
+}
+
+//==============================================================================
+void ConstraintSolver::setFallbackConstraintForceMixingConstant(s_t constant)
+{
+  mFallbackConstraintForceMixingConstant = constant;
 }
 
 //==============================================================================

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -88,7 +88,8 @@ ConstraintSolver::ConstraintSolver()
                 // gradients
     mContactClippingDepth(
         0.03), // Default to clipping only after fairly deep penetration
-    mSolveCallback([this]() { return lcpSolveCallback(); })
+    mEnforceContactAndJointAndCustomConstraints(
+        [this]() { return lcpSolveCallback(); })
 {
 }
 
@@ -373,7 +374,7 @@ LCPSolver* ConstraintSolver::getLCPSolver() const
 //==============================================================================
 void ConstraintSolver::solve()
 {
-  mSolveCallback();
+  mEnforceContactAndJointAndCustomConstraints();
 }
 
 //==============================================================================
@@ -383,7 +384,7 @@ void ConstraintSolver::replaceSolveCallback(const solveCallback& f)
          << "BE INCORRECT!!!! Nimble is still under heavy development, and we "
          << "don't yet support differentiating through `timestep()` if you've "
          << "called `replaceSolveCallback()` to customize the solve function.";
-  mSolveCallback = f;
+  mEnforceContactAndJointAndCustomConstraints = f;
 }
 
 //==============================================================================

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -372,9 +372,9 @@ LCPSolver* ConstraintSolver::getLCPSolver() const
 }
 
 //==============================================================================
-void ConstraintSolver::solve(simulation::World* world)
+void ConstraintSolver::solve()
 {
-  mSolveCallback(world);
+  mSolveCallback();
 }
 
 //==============================================================================
@@ -388,7 +388,7 @@ void ConstraintSolver::replaceSolveCallback(const solveCallback& f)
 }
 
 //==============================================================================
-void ConstraintSolver::lcpSolveCallback(simulation::World* world)
+void ConstraintSolver::lcpSolveCallback()
 {
   for (auto& skeleton : mSkeletons)
   {
@@ -405,7 +405,7 @@ void ConstraintSolver::lcpSolveCallback(simulation::World* world)
   buildConstrainedGroups();
 
   // Solve constrained groups
-  solveConstrainedGroups(world);
+  solveConstrainedGroups();
 }
 
 //==============================================================================
@@ -782,7 +782,7 @@ void ConstraintSolver::buildConstrainedGroups()
 }
 
 //==============================================================================
-void ConstraintSolver::solveConstrainedGroups(simulation::World* world)
+void ConstraintSolver::solveConstrainedGroups()
 {
   for (auto& constraintGroup : mConstrainedGroups)
   {
@@ -793,7 +793,7 @@ void ConstraintSolver::solveConstrainedGroups(simulation::World* world)
     if (0u == n)
       continue;
 
-    std::vector<s_t*> impulses = solveConstrainedGroup(constraintGroup, world);
+    std::vector<s_t*> impulses = solveConstrainedGroup(constraintGroup);
     applyConstraintImpulses(constraintGroup.getConstraints(), impulses);
   }
 }

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -380,6 +380,10 @@ void ConstraintSolver::solve(simulation::World* world)
 //==============================================================================
 void ConstraintSolver::replaceSolveCallback(const solveCallback& f)
 {
+  dtwarn << "[ConstraintSolver::replaceSolveCallback] WARNING: GRADIENTS WILL "
+         << "BE INCORRECT!!!! Nimble is still under heavy development, and we "
+         << "don't yet support differentiating through `timestep()` if you've "
+         << "called `replaceSolveCallback()` to customize the solve function.";
   mSolveCallback = f;
 }
 

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -88,8 +88,9 @@ ConstraintSolver::ConstraintSolver()
                 // gradients
     mContactClippingDepth(
         0.03), // Default to clipping only after fairly deep penetration
-    mEnforceContactAndJointAndCustomConstraints(
-        [this]() { return lcpSolveCallback(); })
+    mEnforceContactAndJointAndCustomConstraintsFn([this]() {
+      return enforceContactAndJointAndCustomConstraintsWithLcp();
+    })
 {
 }
 
@@ -374,21 +375,25 @@ LCPSolver* ConstraintSolver::getLCPSolver() const
 //==============================================================================
 void ConstraintSolver::solve()
 {
-  mEnforceContactAndJointAndCustomConstraints();
+  mEnforceContactAndJointAndCustomConstraintsFn();
 }
 
 //==============================================================================
-void ConstraintSolver::replaceSolveCallback(const solveCallback& f)
+void ConstraintSolver::replaceEnforceContactAndJointAndCustomConstraintsFn(
+    const enforceContactAndJointAndCustomConstraintsFnType& f)
 {
-  dtwarn << "[ConstraintSolver::replaceSolveCallback] WARNING: GRADIENTS WILL "
+  dtwarn << "[ConstraintSolver::"
+            "replaceEnforceContactAndJointAndCustomConstraintsFn] WARNING: "
+            "GRADIENTS WILL "
          << "BE INCORRECT!!!! Nimble is still under heavy development, and we "
          << "don't yet support differentiating through `timestep()` if you've "
-         << "called `replaceSolveCallback()` to customize the solve function.";
-  mEnforceContactAndJointAndCustomConstraints = f;
+         << "called `replaceEnforceContactAndJointAndCustomConstraintsFn()` to "
+            "customize the solve function.";
+  mEnforceContactAndJointAndCustomConstraintsFn = f;
 }
 
 //==============================================================================
-void ConstraintSolver::lcpSolveCallback()
+void ConstraintSolver::enforceContactAndJointAndCustomConstraintsWithLcp()
 {
   for (auto& skeleton : mSkeletons)
   {

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -87,7 +87,9 @@ ConstraintSolver::ConstraintSolver()
         false), // Default to no penetration correction, because it breaks our
                 // gradients
     mContactClippingDepth(
-        0.03) // Default to clipping only after fairly deep penetration
+        0.03), // Default to clipping only after fairly deep penetration
+    mSolveCallback(
+        [this](simulation::World* world) { return lcpSolveCallback(world); })
 {
 }
 
@@ -371,6 +373,12 @@ LCPSolver* ConstraintSolver::getLCPSolver() const
 
 //==============================================================================
 void ConstraintSolver::solve(simulation::World* world)
+{
+  mSolveCallback(world);
+}
+
+//==============================================================================
+void ConstraintSolver::lcpSolveCallback(simulation::World* world)
 {
   for (auto& skeleton : mSkeletons)
   {

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -378,6 +378,12 @@ void ConstraintSolver::solve(simulation::World* world)
 }
 
 //==============================================================================
+void ConstraintSolver::replaceSolveCallback(const solveCallback& f)
+{
+  mSolveCallback = f;
+}
+
+//==============================================================================
 void ConstraintSolver::lcpSolveCallback(simulation::World* world)
 {
   for (auto& skeleton : mSkeletons)

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -62,7 +62,8 @@ namespace constraint {
 class ConstraintSolver
 {
 public:
-  using solveCallback = std::function<void(void)>;
+  using enforceContactAndJointAndCustomConstraintsFnType
+      = std::function<void(void)>;
 
   /// Constructor
   ///
@@ -188,11 +189,12 @@ public:
   /// Solve constraint impulses and apply them to the skeletons
   void solve();
 
-  /// Solve callback function that uses LCP.
-  void lcpSolveCallback();
+  /// Enforce contact, joint, and custom constraints using LCP.
+  void enforceContactAndJointAndCustomConstraintsWithLcp();
 
   /// Replace the default solve callback function.
-  void replaceSolveCallback(const solveCallback& f);
+  void replaceEnforceContactAndJointAndCustomConstraintsFn(
+      const enforceContactAndJointAndCustomConstraintsFnType& f);
 
   /// Update constraints
   void updateConstraints();
@@ -352,8 +354,10 @@ protected:
   /// impossibly deep inter-penetration during multiple shooting optimization.
   s_t mContactClippingDepth;
 
-  /// Solve constraints callback function.
-  solveCallback mEnforceContactAndJointAndCustomConstraints;
+  /// Function that we will call during solve() to enforce contact, joint, and
+  /// custom constraints.
+  enforceContactAndJointAndCustomConstraintsFnType
+      mEnforceContactAndJointAndCustomConstraintsFn;
 };
 
 } // namespace constraint

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -62,6 +62,8 @@ namespace constraint {
 class ConstraintSolver
 {
 public:
+  using solveCallback = std::function<void(simulation::World* world)>;
+
   /// Constructor
   ///
   /// \deprecated Deprecated in DART 6.8. Please use other constructors that
@@ -188,6 +190,9 @@ public:
 
   /// Solve callback function that uses LCP.
   void lcpSolveCallback(simulation::World* world);
+
+  /// Replace the default solve callback function.
+  void replaceSolveCallback(const solveCallback& f);
 
   /// Update constraints
   void updateConstraints();
@@ -322,8 +327,6 @@ protected:
   /// This is a simple solution to avoid extremely nasty situations with
   /// impossibly deep inter-penetration during multiple shooting optimization.
   s_t mContactClippingDepth;
-
-  using solveCallback = std::function<void(simulation::World* world)>;
 
   /// Solve constraints callback function.
   solveCallback mSolveCallback;

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -186,6 +186,9 @@ public:
   /// Solve constraint impulses and apply them to the skeletons
   void solve(simulation::World* world);
 
+  /// Solve callback function that uses LCP.
+  void lcpSolveCallback(simulation::World* world);
+
   /// Update constraints
   void updateConstraints();
 
@@ -319,6 +322,11 @@ protected:
   /// This is a simple solution to avoid extremely nasty situations with
   /// impossibly deep inter-penetration during multiple shooting optimization.
   s_t mContactClippingDepth;
+
+  using solveCallback = std::function<void(simulation::World* world)>;
+
+  /// Solve constraints callback function.
+  solveCallback mSolveCallback;
 };
 
 } // namespace constraint

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -353,7 +353,7 @@ protected:
   s_t mContactClippingDepth;
 
   /// Solve constraints callback function.
-  solveCallback mSolveCallback;
+  solveCallback mEnforceContactAndJointAndCustomConstraints;
 };
 
 } // namespace constraint

--- a/dart/neural/BackpropSnapshot.cpp
+++ b/dart/neural/BackpropSnapshot.cpp
@@ -224,9 +224,9 @@ void BackpropSnapshot::backprop(
     // Set up next timestep loss as a map of the real values
 
     std::size_t cursor = 0;
-    for (std::size_t j = 0; j < group->getSkeletons().size(); j++)
+    for (std::size_t j = 0; j < group->getSkeletonNames().size(); j++)
     {
-      SkeletonPtr skel = world->getSkeleton(group->getSkeletons()[j]);
+      SkeletonPtr skel = world->getSkeleton(group->getSkeletonNames()[j]);
       std::size_t dofCursorWorld = mSkeletonOffset[skel->getName()];
       std::size_t dofs = skel->getNumDofs();
 
@@ -256,9 +256,9 @@ void BackpropSnapshot::backprop(
     // Read the values back out of the group backprop
 
     cursor = 0;
-    for (std::size_t j = 0; j < group->getSkeletons().size(); j++)
+    for (std::size_t j = 0; j < group->getSkeletonNames().size(); j++)
     {
-      SkeletonPtr skel = world->getSkeleton(group->getSkeletons()[j]);
+      SkeletonPtr skel = world->getSkeleton(group->getSkeletonNames()[j]);
       std::size_t dofCursorWorld = mSkeletonOffset[skel->getName()];
       std::size_t dofs = skel->getNumDofs();
 
@@ -1669,12 +1669,14 @@ bool BackpropSnapshot::hasBounces()
 }
 
 //==============================================================================
-/// Returns true if we had to deliberately ignore friction on any of our sub-groups in order to solve.
+/// Returns true if we had to deliberately ignore friction on any of our
+/// sub-groups in order to solve.
 bool BackpropSnapshot::getDeliberatelyIgnoreFriction()
 {
   for (auto gradientMatrices : mGradientMatrices)
   {
-    if (gradientMatrices->mDeliberatelyIgnoreFriction) return true;
+    if (gradientMatrices->mDeliberatelyIgnoreFriction)
+      return true;
   }
   return false;
 }
@@ -4243,11 +4245,11 @@ Eigen::MatrixXs BackpropSnapshot::assembleMatrix(
 
     // shuffle the clamps into the main matrix
     std::size_t dofCursorGroup = 0;
-    for (std::size_t k = 0; k < mGradientMatrices[i]->getSkeletons().size();
+    for (std::size_t k = 0; k < mGradientMatrices[i]->getSkeletonNames().size();
          k++)
     {
       SkeletonPtr skel
-          = world->getSkeleton(mGradientMatrices[i]->getSkeletons()[k]);
+          = world->getSkeleton(mGradientMatrices[i]->getSkeletonNames()[k]);
       // This maps to the row in the world matrix
       std::size_t dofCursorWorld = mSkeletonOffset[skel->getName()];
 
@@ -4394,7 +4396,7 @@ Vec BackpropSnapshot::assembleVector(VectorToAssemble whichVector)
       const Vec& vec
           = getVectorToAssemble<Vec>(mGradientMatrices[i], whichVector);
       int groupCursor = 0;
-      for (auto skelName : mGradientMatrices[i]->getSkeletons())
+      for (auto skelName : mGradientMatrices[i]->getSkeletonNames())
       {
         int dofs = mSkeletonDofs[skelName];
         int worldOffset = mSkeletonOffset[skelName];

--- a/dart/neural/ConstrainedGroupGradientMatrices.cpp
+++ b/dart/neural/ConstrainedGroupGradientMatrices.cpp
@@ -10,8 +10,8 @@
 #include "dart/constraint/LCPUtils.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/Skeleton.hpp"
-#include "dart/math/MathTypes.hpp"
 #include "dart/math/FiniteDifference.hpp"
+#include "dart/math/MathTypes.hpp"
 #include "dart/neural/NeuralUtils.hpp"
 #include "dart/neural/RestorableSnapshot.hpp"
 #include "dart/simulation/World.hpp"
@@ -53,10 +53,10 @@ ConstrainedGroupGradientMatrices::ConstrainedGroupGradientMatrices(
 
       // Only add this skeleton to our list if it's not already present
 
-      if (std::find(mSkeletons.begin(), mSkeletons.end(), skel->getName())
-          == mSkeletons.end())
+      if (std::find(mSkeletonNames.begin(), mSkeletonNames.end(), skel->getName())
+          == mSkeletonNames.end())
       {
-        mSkeletons.push_back(skel->getName());
+        mSkeletonNames.push_back(skel->getName());
         mSkeletonOffset[skel->getName()] = mNumDOFs;
         mNumDOFs += skel->getNumDofs();
         skeletons.push_back(skel);
@@ -81,8 +81,10 @@ ConstrainedGroupGradientMatrices::ConstrainedGroupGradientMatrices(
     mPreLCPVelocities.segment(cursor, dofs) = skel->getVelocities();
     mPreStepVelocities.segment(cursor, dofs)
         = skel->getVelocities() - (timeStep * skel->getAccelerations());
-    mPreStepPositions.segment(cursor,dofs)
-        = skel->getPositions() - (timeStep * (skel->getVelocities()-(timeStep*skel->getAccelerations())));
+    mPreStepPositions.segment(cursor, dofs)
+        = skel->getPositions()
+          - (timeStep
+             * (skel->getVelocities() - (timeStep * skel->getAccelerations())));
     cursor += dofs;
   }
 }
@@ -212,7 +214,7 @@ bool ConstrainedGroupGradientMatrices::isSolutionValid(
 /// this method returns true if it's found a valid solution, whether it
 /// changed anything or not, and false if the solution is invalid.
 bool ConstrainedGroupGradientMatrices::opportunisticallyStandardizeResults(
-    simulation::World* world, Eigen::VectorXs& mX)
+    Eigen::VectorXs& mX)
 {
   mStandardizedResults = true;
   if (mX.size() == 0)
@@ -270,10 +272,6 @@ bool ConstrainedGroupGradientMatrices::opportunisticallyStandardizeResults(
   1e-11); #endif
     }
   */
-  // TODO: <remove>
-  mStabilizationPos = world->getPositions();
-  mStabilizationVel = world->getVelocities();
-  // TODO: </remove>
   mStabilizationQ = Q;
   mStabilizationB = b;
 
@@ -327,7 +325,7 @@ bool ConstrainedGroupGradientMatrices::opportunisticallyStandardizeResults(
     {
       // If any previously clamping indices have become "not clamping" then
       // we need to reconstruct our matrices
-      constructMatrices(world);
+      constructMatrices();
     }
     return true;
   }
@@ -480,7 +478,7 @@ void ConstrainedGroupGradientMatrices::deduplicateConstraints()
 /// be called once, and after this is called you cannot call
 /// measureConstraintImpulse() again!
 void ConstrainedGroupGradientMatrices::constructMatrices(
-    simulation::World* world, Eigen::VectorXi overrideClasses)
+    Eigen::VectorXi overrideClasses)
 {
   // in the new world, we can actually call this multiple times
   // assert(!mFinalized);
@@ -754,8 +752,7 @@ void ConstrainedGroupGradientMatrices::constructMatrices(
             mConstraints[j], mConstraintIndices[j], mX(j));
     mDifferentiableConstraints.push_back(constraint);
 
-    mAllConstraintMatrix.col(j)
-        = constraint->getConstraintForces(world, mSkeletons);
+    mAllConstraintMatrix.col(j) = constraint->getConstraintForces(mSkeletonNames);
 
     if (mContactConstraintMappings(j) == neural::ConstraintMapping::CLAMPING)
     {
@@ -790,7 +787,7 @@ void ConstrainedGroupGradientMatrices::constructMatrices(
 
       mUpperBoundConstraints.push_back(constraint);
       mUpperBoundConstraintMatrix.col(mUpperBoundIndex[j])
-          = constraint->getConstraintForces(world, mSkeletons);
+          = constraint->getConstraintForces(mSkeletonNames);
       mMassedUpperBoundConstraintMatrix.col(mUpperBoundIndex[j])
           = mMassedImpulseTests[j];
     }
@@ -868,7 +865,7 @@ void ConstrainedGroupGradientMatrices::constructMatrices(
   }
   // If possible (if A is rank-deficient), change to an equivalent
   // least-squares solution that also satisfies the LCP
-  opportunisticallyStandardizeResults(world, mX);
+  opportunisticallyStandardizeResults(mX);
 }
 
 //==============================================================================
@@ -935,12 +932,14 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getVelVelJacobian(
   {
     jac = Eigen::MatrixXs::Identity(mNumDOFs, mNumDOFs)
           - getControlForceVelJacobian(world) * getVelCJacobian(world)
-          - dt*Minv*ddamp.asDiagonal()-dt*dt*Minv*spring_stiffs.asDiagonal();
+          - dt * Minv * ddamp.asDiagonal()
+          - dt * dt * Minv * spring_stiffs.asDiagonal();
   }
   else
   {
-    jac = getVelJacobianWrt(world, WithRespectTo::VELOCITY) 
-          - dt*Minv*ddamp.asDiagonal()-dt*dt*Minv*spring_stiffs.asDiagonal();
+    jac = getVelJacobianWrt(world, WithRespectTo::VELOCITY)
+          - dt * Minv * ddamp.asDiagonal()
+          - dt * dt * Minv * spring_stiffs.asDiagonal();
   }
 
 #ifdef LOG_PERFORMANCE_CONSTRAINED_GROUP
@@ -1034,9 +1033,9 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getPosCJacobian(
   Eigen::MatrixXs posCJac = Eigen::MatrixXs::Zero(mNumDOFs, mNumDOFs);
   posCJac.setZero();
   std::size_t cursor = 0;
-  for (std::size_t i = 0; i < mSkeletons.size(); i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::size_t skelDOF = skel->getNumDofs();
     posCJac.block(cursor, cursor, skelDOF, skelDOF)
         = skel->getJacobianOfC(WithRespectTo::POSITION);
@@ -1052,9 +1051,9 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getVelCJacobian(
   Eigen::MatrixXs velCJac = Eigen::MatrixXs::Zero(mNumDOFs, mNumDOFs);
   velCJac.setZero();
   std::size_t cursor = 0;
-  for (std::size_t i = 0; i < mSkeletons.size(); i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::size_t skelDOF = skel->getNumDofs();
     velCJac.block(cursor, cursor, skelDOF, skelDOF) = skel->getVelCJacobian();
     cursor += skelDOF;
@@ -1068,9 +1067,9 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getMassMatrix(WorldPtr world)
   Eigen::MatrixXs massMatrix = Eigen::MatrixXs::Zero(mNumDOFs, mNumDOFs);
   massMatrix.setZero();
   std::size_t cursor = 0;
-  for (std::size_t i = 0; i < mSkeletons.size(); i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::size_t skelDOF = skel->getNumDofs();
     massMatrix.block(cursor, cursor, skelDOF, skelDOF) = skel->getMassMatrix();
     cursor += skelDOF;
@@ -1085,9 +1084,9 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getInvMassMatrix(
   Eigen::MatrixXs invMassMatrix = Eigen::MatrixXs::Zero(mNumDOFs, mNumDOFs);
   invMassMatrix.setZero();
   std::size_t cursor = 0;
-  for (std::size_t i = 0; i < mSkeletons.size(); i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::size_t skelDOF = skel->getNumDofs();
     invMassMatrix.block(cursor, cursor, skelDOF, skelDOF)
         = skel->getInvMassMatrix();
@@ -1097,100 +1096,93 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getInvMassMatrix(
 }
 
 Eigen::VectorXs ConstrainedGroupGradientMatrices::getDampingVector(
-  WorldPtr world
-)
+    WorldPtr world)
 {
   Eigen::VectorXs result = Eigen::VectorXs::Zero(mNumDOFs);
   std::size_t cursor = 0;
-  for(std::size_t i=0;i<mSkeletons.size();i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::vector<dynamics::DegreeOfFreedom*> skeldofs = skel->getDofs();
     std::size_t nDofs = skel->getNumDofs();
-    for (int j=0;j<nDofs;j++)
+    for (int j = 0; j < nDofs; j++)
     {
       result(cursor) = skeldofs[j]->getDampingCoefficient();
-      cursor ++;
+      cursor++;
     }
   }
   return result;
 }
 
 Eigen::VectorXs ConstrainedGroupGradientMatrices::getSpringStiffVector(
-  WorldPtr world
-)
+    WorldPtr world)
 {
   Eigen::VectorXs result = Eigen::VectorXs::Zero(mNumDOFs);
   std::size_t cursor = 0;
-  for (std::size_t i=0;i<mSkeletons.size();i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::vector<dynamics::DegreeOfFreedom*> skeldofs = skel->getDofs();
     std::size_t nDofs = skel->getNumDofs();
-    for (int j=0;j<nDofs;j++)
+    for (int j = 0; j < nDofs; j++)
     {
       result(cursor) = skeldofs[j]->getSpringStiffness();
-      cursor ++;
+      cursor++;
     }
   }
   return result;
 }
 
 Eigen::VectorXs ConstrainedGroupGradientMatrices::getRestPositions(
-  WorldPtr world
-)
+    WorldPtr world)
 {
   Eigen::VectorXs result = Eigen::VectorXs::Zero(mNumDOFs);
   std::size_t cursor = 0;
-  for (std::size_t i=0;i<mSkeletons.size();i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::vector<dynamics::DegreeOfFreedom*> skeldofs = skel->getDofs();
     std::size_t nDofs = skel->getNumDofs();
-    for (int j=0;j<nDofs;j++)
+    for (int j = 0; j < nDofs; j++)
     {
       result(cursor) = skeldofs[j]->getRestPosition();
-      cursor ++;
+      cursor++;
     }
   }
   return result;
 }
 
-Eigen::VectorXs ConstrainedGroupGradientMatrices::getPositions(
-  WorldPtr world
-)
+Eigen::VectorXs ConstrainedGroupGradientMatrices::getPositions(WorldPtr world)
 {
   Eigen::VectorXs p = Eigen::VectorXs::Zero(mNumDOFs);
   std::size_t cursor = 0;
-  for(std::size_t i=0; i<mSkeletons.size();i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::vector<dynamics::DegreeOfFreedom*> skeldofs = skel->getDofs();
     std::size_t nDofs = skel->getNumDofs();
-    for (int j=0;j<nDofs;j++)
+    for (int j = 0; j < nDofs; j++)
     {
       p(cursor) = skeldofs[j]->getPosition();
-      cursor ++;
+      cursor++;
     }
   }
   return p;
 }
 
-Eigen::VectorXs ConstrainedGroupGradientMatrices::getVelocities(
-  WorldPtr world
-)
+Eigen::VectorXs ConstrainedGroupGradientMatrices::getVelocities(WorldPtr world)
 {
   Eigen::VectorXs v = Eigen::VectorXs::Zero(mNumDOFs);
   std::size_t cursor = 0;
-  for(std::size_t i=0; i<mSkeletons.size();i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::vector<dynamics::DegreeOfFreedom*> skeldofs = skel->getDofs();
     std::size_t nDofs = skel->getNumDofs();
-    for (int j=0;j<nDofs;j++)
+    for (int j = 0; j < nDofs; j++)
     {
       v(cursor) = skeldofs[j]->getVelocity();
-      cursor ++;
+      cursor++;
     }
   }
   return v;
@@ -1202,9 +1194,9 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getJointsPosPosJacobian(
 {
   Eigen::MatrixXs jac = Eigen::MatrixXs::Zero(mNumDOFs, mNumDOFs);
   int cursor = 0;
-  for (std::size_t i = 0; i < mSkeletons.size(); i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     int dofs = skel->getNumDofs();
     jac.block(cursor, cursor, dofs, dofs) = skel->getPosPosJac(
         skel->getPositions(), skel->getVelocities(), mTimeStep);
@@ -1219,9 +1211,9 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getJointsVelPosJacobian(
 {
   Eigen::MatrixXs jac = Eigen::MatrixXs::Zero(mNumDOFs, mNumDOFs);
   int cursor = 0;
-  for (std::size_t i = 0; i < mSkeletons.size(); i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     int dofs = skel->getNumDofs();
     jac.block(cursor, cursor, dofs, dofs) = skel->getVelPosJac(
         skel->getPositions(), skel->getVelocities(), mTimeStep);
@@ -1309,7 +1301,7 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getVelJacobianWrt(
 {
   int wrtDim = 0;
   int dofs = 0;
-  for (const std::string& skelName : mSkeletons)
+  for (const std::string& skelName : mSkeletonNames)
   {
     auto skel = world->getSkeleton(skelName);
     wrtDim += wrt->dim(skel.get());
@@ -1333,11 +1325,14 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getVelJacobianWrt(
   Eigen::VectorXs p_t = getPositions(world);
   Eigen::VectorXs spring_stiffs = getSpringStiffVector(world);
   Eigen::VectorXs p_rest = getRestPositions(world);
-  Eigen::VectorXs spring_forces = spring_stiffs.asDiagonal()*(p_t - p_rest + dt*v_t);
-  Eigen::VectorXs damping_forces = ddamp.asDiagonal()*v_t;
+  Eigen::VectorXs spring_forces
+      = spring_stiffs.asDiagonal() * (p_t - p_rest + dt * v_t);
+  Eigen::VectorXs damping_forces = ddamp.asDiagonal() * v_t;
 
-  Eigen::MatrixXs dM
-      = getJacobianOfMinv(world, dt * (tau - C - damping_forces - spring_forces) + A_c_ub_E * f_c, wrt);
+  Eigen::MatrixXs dM = getJacobianOfMinv(
+      world,
+      dt * (tau - C - damping_forces - spring_forces) + A_c_ub_E * f_c,
+      wrt);
 
   Eigen::MatrixXs Minv = getInvMassMatrix(world);
 
@@ -1361,7 +1356,8 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getVelJacobianWrt(
   {
     Eigen::MatrixXs dA_c = getJacobianOfClampingConstraints(world, f_c);
     Eigen::MatrixXs dA_ubE = getJacobianOfUpperBoundConstraints(world, E * f_c);
-    return dM + Minv * (A_c_ub_E * dF_c + dA_c + dA_ubE - dt * dC) - Minv*dt*spring_stiffs.asDiagonal();
+    return dM + Minv * (A_c_ub_E * dF_c + dA_c + dA_ubE - dt * dC)
+           - Minv * dt * spring_stiffs.asDiagonal();
   }
   else
   {
@@ -1634,7 +1630,7 @@ ConstrainedGroupGradientMatrices::getJacobianOfLCPOffsetClampingSubset(
     Eigen::MatrixXs ddamp = getDampingVector(world).asDiagonal();
     return getBounceDiagonals().asDiagonal() * -A_c.transpose()
            * (Eigen::MatrixXs::Identity(mNumDOFs, mNumDOFs)
-           - dt*Minv*(dC+ddamp+dt*spring_stiffs));
+              - dt * Minv * (dC + ddamp + dt * spring_stiffs));
   }
   else if (wrt == WithRespectTo::FORCE)
   {
@@ -1646,11 +1642,11 @@ ConstrainedGroupGradientMatrices::getJacobianOfLCPOffsetClampingSubset(
   Eigen::VectorXs v_f = mPreLCPVelocities;
   Eigen::VectorXs v_t = getVelocities(world);
   Eigen::VectorXs p_t = getPositions(world);
-  
+
   Eigen::MatrixXs ddamp = getDampingVector(world).asDiagonal();
   Eigen::MatrixXs p_rest = getRestPositions(world);
-  Eigen::VectorXs spring_force = spring_stiffs*(p_t - p_rest + dt*v_t);
-  Eigen::VectorXs damping_force = ddamp*v_t;
+  Eigen::VectorXs spring_force = spring_stiffs * (p_t - p_rest + dt * v_t);
+  Eigen::VectorXs damping_force = ddamp * v_t;
   f = f - damping_force - spring_force;
   Eigen::MatrixXs dMinv_f = getJacobianOfMinv(world, f, wrt);
 
@@ -1660,7 +1656,9 @@ ConstrainedGroupGradientMatrices::getJacobianOfLCPOffsetClampingSubset(
         = getJacobianOfClampingConstraintsTranspose(world, v_f);
 
     return getBounceDiagonals().asDiagonal()
-           * -(dA_c_f + A_c.transpose() * dt * (dMinv_f - Minv * dC - Minv*spring_stiffs));
+           * -(dA_c_f
+               + A_c.transpose() * dt
+                     * (dMinv_f - Minv * dC - Minv * spring_stiffs));
   }
   else
   {
@@ -1694,26 +1692,27 @@ void ConstrainedGroupGradientMatrices::computeLCPOffsetClampingSubset(
   int nDofs = world->getNumDofs();
   s_t dt = world->getTimeStep();
   std::vector<dynamics::DegreeOfFreedom*> dofs = world->getDofs();
-  Eigen::MatrixXs damp = Eigen::MatrixXs::Zero(nDofs,nDofs);
-  Eigen::MatrixXs spring_stiffs = Eigen::MatrixXs::Zero(nDofs,nDofs);
+  Eigen::MatrixXs damp = Eigen::MatrixXs::Zero(nDofs, nDofs);
+  Eigen::MatrixXs spring_stiffs = Eigen::MatrixXs::Zero(nDofs, nDofs);
   Eigen::VectorXs p_rest = Eigen::VectorXs::Zero(nDofs);
   Eigen::VectorXs p_t = world->getPositions();
   Eigen::VectorXs v_t = world->getVelocities();
-  for (int i=0;i<nDofs;i++)
+  for (int i = 0; i < nDofs; i++)
   {
-    damp(i,i) = dofs[i]->getDampingCoefficient();
-    spring_stiffs(i,i) = dofs[i]->getSpringStiffness();
+    damp(i, i) = dofs[i]->getDampingCoefficient();
+    spring_stiffs(i, i) = dofs[i]->getSpringStiffness();
     p_rest(i) = dofs[i]->getRestPosition();
   }
-  Eigen::VectorXs damping_force = damp*v_t;
-  Eigen::VectorXs spring_force = spring_stiffs*(p_t-p_rest+dt*v_t);
+  Eigen::VectorXs damping_force = damp * v_t;
+  Eigen::VectorXs spring_force = spring_stiffs * (p_t - p_rest + dt * v_t);
   b = -A_c.transpose()
       * (v_t
          + (dt
             * implicitMultiplyByInvMassMatrix(
                 world,
                 world->getControlForces()
-                    - world->getCoriolisAndGravityAndExternalForces() - damping_force - spring_force)));
+                    - world->getCoriolisAndGravityAndExternalForces()
+                    - damping_force - spring_force)));
 }
 
 //==============================================================================
@@ -1745,9 +1744,9 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getJacobianOfMinv(
 {
   Eigen::MatrixXs jac = Eigen::MatrixXs::Zero(mNumDOFs, mNumDOFs);
   int cursor = 0;
-  for (int i = 0; i < mSkeletons.size(); i++)
+  for (int i = 0; i < mSkeletonNames.size(); i++)
   {
-    auto skel = world->getSkeleton(mSkeletons[i]);
+    auto skel = world->getSkeleton(mSkeletonNames[i]);
     int dofs = skel->getNumDofs();
     jac.block(cursor, cursor, dofs, dofs)
         = skel->getJacobianOfMinv(tau.segment(cursor, dofs), wrt);
@@ -1769,7 +1768,7 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::getJacobianOfC(
 
   int wrtCursor = 0;
   int dofCursor = 0;
-  for (const std::string& skelName : mSkeletons)
+  for (const std::string& skelName : mSkeletonNames)
   {
     auto skel = world->getSkeleton(skelName);
     int dofs = skel->getNumDofs();
@@ -1876,9 +1875,9 @@ Eigen::VectorXs ConstrainedGroupGradientMatrices::implicitMultiplyByMassMatrix(
 {
   Eigen::VectorXs result = Eigen::VectorXs::Zero(getNumDOFs());
   std::size_t cursor = 0;
-  for (std::size_t i = 0; i < mSkeletons.size(); i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::size_t dofs = skel->getNumDofs();
     result.segment(cursor, dofs)
         = skel->multiplyByImplicitMassMatrix(x.segment(cursor, dofs));
@@ -1896,9 +1895,9 @@ ConstrainedGroupGradientMatrices::implicitMultiplyByInvMassMatrix(
 {
   Eigen::VectorXs result = Eigen::VectorXs::Zero(getNumDOFs());
   std::size_t cursor = 0;
-  for (std::size_t i = 0; i < mSkeletons.size(); i++)
+  for (std::size_t i = 0; i < mSkeletonNames.size(); i++)
   {
-    SkeletonPtr skel = world->getSkeleton(mSkeletons[i]);
+    SkeletonPtr skel = world->getSkeleton(mSkeletonNames[i]);
     std::size_t dofs = skel->getNumDofs();
     result.segment(cursor, dofs)
         = skel->multiplyByImplicitInvMassMatrix(x.segment(cursor, dofs));
@@ -1993,7 +1992,7 @@ void ConstrainedGroupGradientMatrices::backprop(
         }
       }
     }
-    constructMatrices(world.get(), overrideClasses);
+    constructMatrices(overrideClasses);
 
     Eigen::MatrixXs stratForceVelJacobian = getControlForceVelJacobian(world);
     // p_t+1 <-- v_t
@@ -2033,7 +2032,7 @@ void ConstrainedGroupGradientMatrices::backprop(
 
     // Reset the matrices, just in case people ask for Jacobians or something
     // later, don't want to give them the wrong one.
-    constructMatrices(world.get());
+    constructMatrices();
   }
 
   /*
@@ -2103,10 +2102,10 @@ void ConstrainedGroupGradientMatrices::clipLossGradientsToBounds(
     Eigen::VectorXs& lossWrtForce)
 {
   int cursor = 0;
-  for (int i = 0; i < mSkeletons.size(); i++)
+  for (int i = 0; i < mSkeletonNames.size(); i++)
   {
     std::shared_ptr<dynamics::Skeleton> skel
-        = world->getSkeleton(mSkeletons[i]);
+        = world->getSkeleton(mSkeletonNames[i]);
     for (int j = 0; j < skel->getNumDofs(); j++)
     {
       // Clip position gradients
@@ -2247,10 +2246,10 @@ std::size_t ConstrainedGroupGradientMatrices::getNumConstraintDim() const
 }
 
 //==============================================================================
-const std::vector<std::string>& ConstrainedGroupGradientMatrices::getSkeletons()
+const std::vector<std::string>& ConstrainedGroupGradientMatrices::getSkeletonNames()
     const
 {
-  return mSkeletons;
+  return mSkeletonNames;
 }
 
 //==============================================================================
@@ -2358,7 +2357,7 @@ ConstrainedGroupGradientMatrices::getCoriolisAndGravityAndExternalForces(
 {
   Eigen::VectorXs result = Eigen::VectorXs::Zero(mNumDOFs);
   int cursor = 0;
-  for (std::string skelName : mSkeletons)
+  for (std::string skelName : mSkeletonNames)
   {
     std::shared_ptr<dynamics::Skeleton> skel = world->getSkeleton(skelName);
     int dofs = skel->getNumDofs();
@@ -2398,18 +2397,18 @@ ConstrainedGroupGradientMatrices::finiteDifferenceJacobianOfMinv(
 
   s_t eps = useRidders ? 1e-3 : 5e-7;
   finiteDifference(
-    [&](/* in*/ s_t eps,
-        /* in*/ int dof,
-        /*out*/ Eigen::VectorXs& perturbed) {
-      Eigen::VectorXs tweakedWrt = originalWrt;
-      tweakedWrt(dof) += eps;
-      setWrt(world, wrt, tweakedWrt);
-      perturbed = implicitMultiplyByInvMassMatrix(world, tau);
-      return true;
-    },
-    result,
-    eps,
-    useRidders);
+      [&](/* in*/ s_t eps,
+          /* in*/ int dof,
+          /*out*/ Eigen::VectorXs& perturbed) {
+        Eigen::VectorXs tweakedWrt = originalWrt;
+        tweakedWrt(dof) += eps;
+        setWrt(world, wrt, tweakedWrt);
+        perturbed = implicitMultiplyByInvMassMatrix(world, tau);
+        return true;
+      },
+      result,
+      eps,
+      useRidders);
 
   setWrt(world, wrt, originalWrt);
   return result;
@@ -2427,18 +2426,18 @@ Eigen::MatrixXs ConstrainedGroupGradientMatrices::finiteDifferenceJacobianOfC(
 
   s_t eps = useRidders ? 1e-3 : 1e-7;
   finiteDifference(
-    [&](/* in*/ s_t eps,
-        /* in*/ int dof,
-        /*out*/ Eigen::VectorXs& perturbed) {
-      Eigen::VectorXs tweakedWrt = originalWrt;
-      tweakedWrt(dof) += eps;
-      setWrt(world, wrt, tweakedWrt);
-      perturbed = getCoriolisAndGravityAndExternalForces(world);
-      return true;
-    },
-    result,
-    eps,
-    useRidders);
+      [&](/* in*/ s_t eps,
+          /* in*/ int dof,
+          /*out*/ Eigen::VectorXs& perturbed) {
+        Eigen::VectorXs tweakedWrt = originalWrt;
+        tweakedWrt(dof) += eps;
+        setWrt(world, wrt, tweakedWrt);
+        perturbed = getCoriolisAndGravityAndExternalForces(world);
+        return true;
+      },
+      result,
+      eps,
+      useRidders);
 
   setWrt(world, wrt, originalWrt);
   return result;
@@ -2449,7 +2448,7 @@ std::size_t ConstrainedGroupGradientMatrices::getWrtDim(
     simulation::WorldPtr world, WithRespectTo* wrt)
 {
   int sum = 0;
-  for (auto skel : mSkeletons)
+  for (auto skel : mSkeletonNames)
   {
     sum += wrt->dim(world->getSkeleton(skel).get());
   }
@@ -2462,7 +2461,7 @@ Eigen::VectorXs ConstrainedGroupGradientMatrices::getWrt(
 {
   Eigen::VectorXs result = Eigen::VectorXs::Zero(getWrtDim(world, wrt));
   int cursor = 0;
-  for (auto skelName : mSkeletons)
+  for (auto skelName : mSkeletonNames)
   {
     dynamics::Skeleton* skel = world->getSkeleton(skelName).get();
     int dims = wrt->dim(skel);
@@ -2477,7 +2476,7 @@ void ConstrainedGroupGradientMatrices::setWrt(
     simulation::WorldPtr world, WithRespectTo* wrt, Eigen::VectorXs v)
 {
   int cursor = 0;
-  for (auto skelName : mSkeletons)
+  for (auto skelName : mSkeletonNames)
   {
     dynamics::Skeleton* skel = world->getSkeleton(skelName).get();
     int dims = wrt->dim(skel);
@@ -2492,7 +2491,7 @@ std::vector<std::shared_ptr<dynamics::Skeleton>>
 ConstrainedGroupGradientMatrices::getSkeletons(simulation::WorldPtr world)
 {
   std::vector<std::shared_ptr<dynamics::Skeleton>> skels;
-  for (auto skelName : mSkeletons)
+  for (auto skelName : mSkeletonNames)
   {
     skels.push_back(world->getSkeleton(skelName));
   }

--- a/dart/neural/ConstrainedGroupGradientMatrices.cpp
+++ b/dart/neural/ConstrainedGroupGradientMatrices.cpp
@@ -53,10 +53,12 @@ ConstrainedGroupGradientMatrices::ConstrainedGroupGradientMatrices(
 
       // Only add this skeleton to our list if it's not already present
 
-      if (std::find(mSkeletonNames.begin(), mSkeletonNames.end(), skel->getName())
+      if (std::find(
+              mSkeletonNames.begin(), mSkeletonNames.end(), skel->getName())
           == mSkeletonNames.end())
       {
         mSkeletonNames.push_back(skel->getName());
+        mSkeletons.push_back(skel);
         mSkeletonOffset[skel->getName()] = mNumDOFs;
         mNumDOFs += skel->getNumDofs();
         skeletons.push_back(skel);
@@ -752,7 +754,7 @@ void ConstrainedGroupGradientMatrices::constructMatrices(
             mConstraints[j], mConstraintIndices[j], mX(j));
     mDifferentiableConstraints.push_back(constraint);
 
-    mAllConstraintMatrix.col(j) = constraint->getConstraintForces(mSkeletonNames);
+    mAllConstraintMatrix.col(j) = constraint->getConstraintForces(mSkeletons);
 
     if (mContactConstraintMappings(j) == neural::ConstraintMapping::CLAMPING)
     {
@@ -787,7 +789,7 @@ void ConstrainedGroupGradientMatrices::constructMatrices(
 
       mUpperBoundConstraints.push_back(constraint);
       mUpperBoundConstraintMatrix.col(mUpperBoundIndex[j])
-          = constraint->getConstraintForces(mSkeletonNames);
+          = constraint->getConstraintForces(mSkeletons);
       mMassedUpperBoundConstraintMatrix.col(mUpperBoundIndex[j])
           = mMassedImpulseTests[j];
     }
@@ -2246,8 +2248,8 @@ std::size_t ConstrainedGroupGradientMatrices::getNumConstraintDim() const
 }
 
 //==============================================================================
-const std::vector<std::string>& ConstrainedGroupGradientMatrices::getSkeletonNames()
-    const
+const std::vector<std::string>&
+ConstrainedGroupGradientMatrices::getSkeletonNames() const
 {
   return mSkeletonNames;
 }

--- a/dart/neural/ConstrainedGroupGradientMatrices.hpp
+++ b/dart/neural/ConstrainedGroupGradientMatrices.hpp
@@ -8,6 +8,7 @@
 
 #include <Eigen/Dense>
 
+#include "dart/dynamics/Skeleton.hpp"
 #include "dart/neural/DifferentiableContactConstraint.hpp"
 #include "dart/neural/NeuralConstants.hpp"
 #include "dart/neural/NeuralUtils.hpp"
@@ -107,8 +108,7 @@ public:
   /// cleaned up by this method and made exact. To faccilitate that use case,
   /// this method returns true if it's found a valid solution, whether it
   /// changed anything or not, and false if the solution is invalid.
-  bool opportunisticallyStandardizeResults(
-      simulation::World* world, Eigen::VectorXs& mX);
+  bool opportunisticallyStandardizeResults(Eigen::VectorXs& mX);
 
   /// This returns true if the proposed mX is consistent with our recorded LCP
   /// construction
@@ -122,7 +122,6 @@ public:
   /// be called once, and after this is called you cannot call
   /// measureConstraintImpulse() again!
   void constructMatrices(
-      simulation::World* world,
       Eigen::VectorXi overrideClasses = Eigen::VectorXi::Zero(0));
 
   /// This computes and returns the whole vel-vel jacobian for this group. For
@@ -539,6 +538,10 @@ public:
 
   /// These are the names of skeletons that are covered by this constraint group
   std::vector<std::string> mSkeletonNames;
+
+  /// The list of skeletons that are covered by this constraint group. They
+  /// correspond to the skeleton names in mSkeletonNames.
+  std::vector<dart::dynamics::SkeletonPtr> mSkeletons;
 
   /// For each index in the original force vector, this either points to an
   /// index in the clamping vector, or it contains -1 to indicate the index was

--- a/dart/neural/ConstrainedGroupGradientMatrices.hpp
+++ b/dart/neural/ConstrainedGroupGradientMatrices.hpp
@@ -57,8 +57,7 @@ public:
       const std::shared_ptr<constraint::ConstraintBase>& constraint);
 
   /// This mocks registering a constaint. Useful for testing.
-  void mockRegisterConstraint(
-      s_t restitutionCoeff, s_t penetrationHackVel);
+  void mockRegisterConstraint(s_t restitutionCoeff, s_t penetrationHackVel);
 
   /// This gets called during the setup of the ConstrainedGroupGradientMatrices
   /// at each constraint's dimension. It gets called _after_ the system has
@@ -176,13 +175,16 @@ public:
   /// concatenation of the skeleton inverse mass matrices.
   Eigen::MatrixXs getInvMassMatrix(simulation::WorldPtr world);
 
-  /// This result the diagonal matrix where damping of each joint has been considered
+  /// This result the diagonal matrix where damping of each joint has been
+  /// considered
   Eigen::VectorXs getDampingVector(simulation::WorldPtr world);
 
-  /// This result the diagonal matrix(vector) where spring stiffness of each joint has been considered
+  /// This result the diagonal matrix(vector) where spring stiffness of each
+  /// joint has been considered
   Eigen::VectorXs getSpringStiffVector(simulation::WorldPtr world);
 
-  /// This result the diagonal matrix(vector) where rest position of spring lives
+  /// This result the diagonal matrix(vector) where rest position of spring
+  /// lives
   Eigen::VectorXs getRestPositions(simulation::WorldPtr world);
 
   /// This result is the current velocity of dofs involved in current group
@@ -410,7 +412,7 @@ public:
 
   std::size_t getNumConstraintDim() const;
 
-  const std::vector<std::string>& getSkeletons() const;
+  const std::vector<std::string>& getSkeletonNames() const;
 
   const std::vector<std::shared_ptr<DifferentiableContactConstraint>>&
   getDifferentiableConstraints() const;
@@ -536,7 +538,7 @@ public:
   Eigen::VectorXs mPreLCPVelocities;
 
   /// These are the names of skeletons that are covered by this constraint group
-  std::vector<std::string> mSkeletons;
+  std::vector<std::string> mSkeletonNames;
 
   /// For each index in the original force vector, this either points to an
   /// index in the clamping vector, or it contains -1 to indicate the index was

--- a/dart/neural/DifferentiableContactConstraint.hpp
+++ b/dart/neural/DifferentiableContactConstraint.hpp
@@ -112,6 +112,11 @@ public:
   Eigen::VectorXs getConstraintForces(
       simulation::World* world, std::vector<std::string> skelNames);
 
+  /// This analytically computes a column of the A_c matrix for a set of
+  /// skeletons.
+  Eigen::VectorXs getConstraintForces(
+      std::vector<std::shared_ptr<dynamics::Skeleton>> skels);
+
   /// This analytically computes a column of the A_c matrix, for this contact
   /// constraint, across the whole world by concatenating the result for each
   /// skeleton together into a single vector.

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -164,9 +164,7 @@ public:
   std::size_t getNumSkeletons() const;
 
   /// Add a skeleton to this world
-  std::string addSkeleton(
-      const dynamics::SkeletonPtr& _skeleton
-    );
+  std::string addSkeleton(const dynamics::SkeletonPtr& _skeleton);
 
   /// Remove a skeleton from this world
   void removeSkeleton(const dynamics::SkeletonPtr& _skeleton);
@@ -248,7 +246,7 @@ public:
   /// single vector
   Eigen::VectorXs getMasses();
 
-  //Eigen::VectorXs getLinkMasses();
+  // Eigen::VectorXs getLinkMasses();
 
   size_t getLinkMassesDims();
 
@@ -355,7 +353,7 @@ public:
   void setLinkMassIndex(s_t mass, size_t index);
 
   void setLinkCOMs(Eigen::VectorXs coms);
-  
+
   void setLinkMOIs(Eigen::VectorXs mois);
 
   void setLinkMUs(Eigen::VectorXs mus);

--- a/python/_nimblephysics/constraint/ConstraintSolver.cpp
+++ b/python/_nimblephysics/constraint/ConstraintSolver.cpp
@@ -201,13 +201,14 @@ void ConstraintSolver(py::module& m)
           "solve",
           +[](dart::constraint::ConstraintSolver* self) { self->solve(); })
       .def(
-          "lcpSolveCallback",
+          "enforceContactAndJointAndCustomConstraintsWithLcp",
           +[](dart::constraint::ConstraintSolver* self) {
-            self->lcpSolveCallback();
+            self->enforceContactAndJointAndCustomConstraintsWithLcp();
           })
       .def(
-          "replaceSolveCallback",
-          &dart::constraint::ConstraintSolver::replaceSolveCallback);
+          "replaceEnforceContactAndJointAndCustomConstraintsFn",
+          &dart::constraint::ConstraintSolver::
+              replaceEnforceContactAndJointAndCustomConstraintsFn);
 }
 
 } // namespace python

--- a/python/_nimblephysics/constraint/ConstraintSolver.cpp
+++ b/python/_nimblephysics/constraint/ConstraintSolver.cpp
@@ -200,7 +200,16 @@ void ConstraintSolver(py::module& m)
       .def(
           "solve",
           +[](dart::constraint::ConstraintSolver* self,
-              dart::simulation::World* world) { self->solve(world); });
+              dart::simulation::World* world) { self->solve(world); })
+      .def(
+          "lcpSolveCallback",
+          +[](dart::constraint::ConstraintSolver* self,
+              dart::simulation::World* world) {
+            self->lcpSolveCallback(world);
+          })
+      .def(
+          "replaceSolveCallback",
+          &dart::constraint::ConstraintSolver::replaceSolveCallback);
 }
 
 } // namespace python

--- a/python/_nimblephysics/constraint/ConstraintSolver.cpp
+++ b/python/_nimblephysics/constraint/ConstraintSolver.cpp
@@ -35,6 +35,7 @@
 #include <dart/constraint/ConstrainedGroup.hpp>
 #include <dart/constraint/ConstraintSolver.hpp>
 #include <dart/dynamics/Skeleton.hpp>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 

--- a/python/_nimblephysics/constraint/ConstraintSolver.cpp
+++ b/python/_nimblephysics/constraint/ConstraintSolver.cpp
@@ -194,19 +194,16 @@ void ConstraintSolver(py::module& m)
           })
       .def(
           "solveConstrainedGroups",
-          +[](dart::constraint::ConstraintSolver* self,
-              dart::simulation::World* world) {
-            self->solveConstrainedGroups(world);
+          +[](dart::constraint::ConstraintSolver* self) {
+            self->solveConstrainedGroups();
           })
       .def(
           "solve",
-          +[](dart::constraint::ConstraintSolver* self,
-              dart::simulation::World* world) { self->solve(world); })
+          +[](dart::constraint::ConstraintSolver* self) { self->solve(); })
       .def(
           "lcpSolveCallback",
-          +[](dart::constraint::ConstraintSolver* self,
-              dart::simulation::World* world) {
-            self->lcpSolveCallback(world);
+          +[](dart::constraint::ConstraintSolver* self) {
+            self->lcpSolveCallback();
           })
       .def(
           "replaceSolveCallback",

--- a/python/_nimblephysics/simulation/World.cpp
+++ b/python/_nimblephysics/simulation/World.cpp
@@ -170,6 +170,17 @@ void World(py::module& m)
           },
           ::py::arg("index"))
       .def(
+          "getNumBodyNodes",
+          +[](dart::simulation::World* self) -> std::size_t {
+            return self->getNumBodyNodes();
+          })
+      .def(
+          "getBodyNodeIndex",
+          +[](dart::simulation::World* self,
+              std::size_t _index) -> dart::dynamics::BodyNode* {
+            return self->getBodyNodeIndex(_index);
+          })
+      .def(
           "getSimpleFrame",
           +[](const dart::simulation::World* self,
               std::size_t _index) -> dart::dynamics::SimpleFramePtr {

--- a/python/new_examples/constraint_callback.py
+++ b/python/new_examples/constraint_callback.py
@@ -9,12 +9,29 @@ def dummy_callback(world: nimble.simulation.World):
 def lcp_callback(world: nimble.simulation.World):
     world.getConstraintSolver().lcpSolveCallback(world)
 
+def frictionless_lcp_callback(world: nimble.simulation.World):
+    # Backup and remove friction.
+    friction_coefs = []
+    bodies = []
+    for i in range(world.getNumBodyNodes()):
+        body = world.getBodyNodeIndex(i)
+        bodies.append(body)
+        friction_coefs.append(body.getFrictionCoef())
+        body.setFrictionCoef(0.0)
+        
+    # Frictionless LCP
+    lcp_callback(world)
+
+    # Restore friction.
+    for friction_coef, body in zip(friction_coefs, bodies):
+        body.setFrictionCoef(friction_coef)
+
 def main():
     world = nimble.loadWorld("../../data/skel/test/colliding_cube.skel")
     state = torch.tensor(world.getState())
     action = torch.zeros((world.getNumDofs()))
     solver = world.getConstraintSolver()
-    callbacks = [None, dummy_callback, lcp_callback]
+    callbacks = [None, dummy_callback, lcp_callback, frictionless_lcp_callback]
     for callback in callbacks:
         if callback is not None:
             solver.replaceSolveCallback(callback)

--- a/python/new_examples/constraint_callback.py
+++ b/python/new_examples/constraint_callback.py
@@ -31,10 +31,13 @@ def main():
     state = torch.tensor(world.getState())
     action = torch.zeros((world.getNumDofs()))
     solver = world.getConstraintSolver()
-    callbacks = [None, dummy_callback, lcp_callback, frictionless_lcp_callback]
+    callbacks = [None, dummy_callback, solver.lcpSolveCallback, lcp_callback, frictionless_lcp_callback]
     for callback in callbacks:
         if callback is not None:
             solver.replaceSolveCallback(callback)
+            print(callback.__name__)
+        else:
+            print("None")
         new_state = nimble.timestep(world, state, action)
         print(new_state)
 

--- a/python/new_examples/constraint_callback.py
+++ b/python/new_examples/constraint_callback.py
@@ -16,15 +16,15 @@ def frictionless_lcp_callback(world: nimble.simulation.World):
     for i in range(world.getNumBodyNodes()):
         body = world.getBodyNodeIndex(i)
         bodies.append(body)
-        friction_coefs.append(body.getFrictionCoef())
-        body.setFrictionCoef(0.0)
-        
+        friction_coefs.append(body.getFrictionCoeff())
+        body.setFrictionCoeff(0.0)
+
     # Frictionless LCP
     lcp_callback(world)
 
     # Restore friction.
     for friction_coef, body in zip(friction_coefs, bodies):
-        body.setFrictionCoef(friction_coef)
+        body.setFrictionCoeff(friction_coef)
 
 def main():
     world = nimble.loadWorld("../../data/skel/test/colliding_cube.skel")

--- a/python/new_examples/constraint_callback.py
+++ b/python/new_examples/constraint_callback.py
@@ -6,15 +6,20 @@ import torch
 def dummy_callback(world: nimble.simulation.World):
     pass
 
+def lcp_callback(world: nimble.simulation.World):
+    world.getConstraintSolver().lcpSolveCallback(world)
+
 def main():
     world = nimble.loadWorld("../../data/skel/test/colliding_cube.skel")
     state = torch.tensor(world.getState())
     action = torch.zeros((world.getNumDofs()))
     solver = world.getConstraintSolver()
-    solver.replaceSolveCallback(dummy_callback)
-    new_state = nimble.timestep(world, state, action)
-    print(state)
-    print(new_state)
+    callbacks = [None, dummy_callback, lcp_callback]
+    for callback in callbacks:
+        if callback is not None:
+            solver.replaceSolveCallback(callback)
+        new_state = nimble.timestep(world, state, action)
+        print(new_state)
 
 
 if __name__ == '__main__':

--- a/python/new_examples/constraint_callback.py
+++ b/python/new_examples/constraint_callback.py
@@ -33,12 +33,12 @@ def main():
     callbacks = [
         None,  # Use default LCP, don't replace
         dummy_callback,  # Replace with dummy function
-        solver.lcpSolveCallback,  # Replace with the same function as default
+        solver.enforceContactAndJointAndCustomConstraintsWithLcp,  # Replace with the same function as default
         # frictionless_lcp_callback,
     ]
     for callback in callbacks:
         if callback is not None:
-            solver.replaceSolveCallback(callback)
+            solver.replaceEnforceContactAndJointAndCustomConstraintsFn(callback)
             print(callback.__name__)
         else:
             print("None")

--- a/python/new_examples/constraint_callback.py
+++ b/python/new_examples/constraint_callback.py
@@ -1,0 +1,21 @@
+"""An example of overriding the ConstraintSolver's default callback function."""
+import nimblephysics as nimble
+import torch
+
+
+def dummy_callback(world: nimble.simulation.World):
+    pass
+
+def main():
+    world = nimble.loadWorld("../../data/skel/test/colliding_cube.skel")
+    state = torch.tensor(world.getState())
+    action = torch.zeros((world.getNumDofs()))
+    solver = world.getConstraintSolver()
+    solver.replaceSolveCallback(dummy_callback)
+    new_state = nimble.timestep(world, state, action)
+    print(state)
+    print(new_state)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/new_examples/constraint_callback.py
+++ b/python/new_examples/constraint_callback.py
@@ -3,35 +3,39 @@ import nimblephysics as nimble
 import torch
 
 
-def dummy_callback(world: nimble.simulation.World):
+def dummy_callback():
     pass
 
-def lcp_callback(world: nimble.simulation.World):
-    world.getConstraintSolver().lcpSolveCallback(world)
 
-def frictionless_lcp_callback(world: nimble.simulation.World):
-    # Backup and remove friction.
-    friction_coefs = []
-    bodies = []
-    for i in range(world.getNumBodyNodes()):
-        body = world.getBodyNodeIndex(i)
-        bodies.append(body)
-        friction_coefs.append(body.getFrictionCoeff())
-        body.setFrictionCoeff(0.0)
+# def frictionless_lcp_callback():
+#     # Backup and remove friction.
+#     friction_coefs = []
+#     bodies = []
+#     for i in range(world.getNumBodyNodes()):
+#         body = world.getBodyNodeIndex(i)
+#         bodies.append(body)
+#         friction_coefs.append(body.getFrictionCoeff())
+#         body.setFrictionCoeff(0.0)
 
-    # Frictionless LCP
-    lcp_callback(world)
+#     # Frictionless LCP
+#     lcp_callback()
 
-    # Restore friction.
-    for friction_coef, body in zip(friction_coefs, bodies):
-        body.setFrictionCoeff(friction_coef)
+#     # Restore friction.
+#     for friction_coef, body in zip(friction_coefs, bodies):
+#         body.setFrictionCoeff(friction_coef)
+
 
 def main():
     world = nimble.loadWorld("../../data/skel/test/colliding_cube.skel")
     state = torch.tensor(world.getState())
     action = torch.zeros((world.getNumDofs()))
     solver = world.getConstraintSolver()
-    callbacks = [None, dummy_callback, solver.lcpSolveCallback, lcp_callback, frictionless_lcp_callback]
+    callbacks = [
+        None,  # Use default LCP, don't replace
+        dummy_callback,  # Replace with dummy function
+        solver.lcpSolveCallback,  # Replace with the same function as default
+        # frictionless_lcp_callback,
+    ]
     for callback in callbacks:
         if callback is not None:
             solver.replaceSolveCallback(callback)
@@ -42,5 +46,5 @@ def main():
         print(new_state)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/unittests/GradientTestUtils.hpp
+++ b/unittests/GradientTestUtils.hpp
@@ -144,7 +144,7 @@ bool verifyClassicClampingConstraintMatrix(
   // Populate the constraint matrices, without taking a time step or integrating
   // velocities
   world->getConstraintSolver()->setGradientEnabled(true);
-  world->getConstraintSolver()->solve(world.get());
+  world->getConstraintSolver()->solve();
 
   for (std::size_t i = 0; i < world->getNumSkeletons(); i++)
   {
@@ -2366,8 +2366,7 @@ bool verifyRecoveredLCPConstraints(WorldPtr world, VectorXs proposedVelocities)
         << classicPtr->mGradientMatrices[0]->mConstraintForceMixingConstant
         << std::endl;
     std::cout << "Deliberately ignored friction to solve: "
-              << classicPtr->getDeliberatelyIgnoreFriction()
-              << std::endl;
+              << classicPtr->getDeliberatelyIgnoreFriction() << std::endl;
     std::cout << "Error in verifyRecoveredLCPConstraints():" << std::endl;
     std::cout << "analytical X:" << std::endl << X << std::endl;
     std::cout << "real X:" << std::endl << realX << std::endl;

--- a/unittests/comprehensive/test_Gradients.cpp
+++ b/unittests/comprehensive/test_Gradients.cpp
@@ -392,8 +392,8 @@ void testSphereStack()
   /*
   std::shared_ptr<neural::BackpropSnapshot> snapshot =
   neural::forwardPass(world, true); Eigen::MatrixXs forceVel =
-  snapshot->getControlForceVelJacobian(world); std::cout << "force-vel" << std::endl <<
-  forceVel << std::endl; Eigen::MatrixXs velVel =
+  snapshot->getControlForceVelJacobian(world); std::cout << "force-vel" <<
+  std::endl << forceVel << std::endl; Eigen::MatrixXs velVel =
   snapshot->getVelVelJacobian(world); std::cout << "vel-vel" << std::endl <<
   velVel << std::endl; Eigen::MatrixXs A_c =
   snapshot->getClampingConstraintMatrix(world); std::cout << "A_c" << std::endl

--- a/unittests/comprehensive/test_Gradients.cpp
+++ b/unittests/comprehensive/test_Gradients.cpp
@@ -564,7 +564,7 @@ void testTwoBlocks(
   // Test the classic formulation
 
   world->getConstraintSolver()->setGradientEnabled(true);
-  world->getConstraintSolver()->solve(world.get());
+  world->getConstraintSolver()->solve();
 
   EXPECT_TRUE(verifyVelGradients(world, worldVel));
   EXPECT_TRUE(verifyAnalyticalBackprop(world));

--- a/unittests/unit/test_ConstraintSolver.cpp
+++ b/unittests/unit/test_ConstraintSolver.cpp
@@ -70,8 +70,7 @@ TEST(ConstraintSolver, SIMPLE)
   // Solve constraint impulses.
   for (auto constraintGroup : solver->getConstrainedGroups())
   {
-    std::vector<s_t*> impulses
-        = solver->solveConstrainedGroup(constraintGroup, world.get());
+    std::vector<s_t*> impulses = solver->solveConstrainedGroup(constraintGroup);
     EXPECT_TRUE(impulses.size() > 0);
     solver->applyConstraintImpulses(constraintGroup.getConstraints(), impulses);
   }


### PR DESCRIPTION
Round 3 Review
- Fix unittests and python code still using `world`
- Give a more descriptive name to custom function (`solveCallback` -> `enforceContactAndJointAndCustomConstraints`)

Round 2 Review
- Remove dependency on `world` inputs.
- Add warning message about not supporting differentiation through custom callback functions.

Round 1 Review
- Create `mSolveCallback` callback function.