### PR TITLE
`integrateVelocitiesFromImpulses` and `integratePositions`

### DIFF
--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -242,26 +242,7 @@ void World::step(bool _resetCommand)
   mConstraintSolver->setFallbackConstraintForceMixingConstant(
       mFallbackConstraintForceMixingConstant);
   mConstraintSolver->solve();
-
-  // Compute velocity changes given constraint impulses
-  for (auto& skel : mSkeletons)
-  {
-    if (!skel->isMobile())
-      continue;
-
-    if (skel->isImpulseApplied())
-    {
-      skel->computeImpulseForwardDynamics();
-      skel->setImpulseApplied(false);
-    }
-
-    if (_resetCommand)
-    {
-      skel->clearInternalForces();
-      skel->clearExternalForces();
-      skel->resetCommands();
-    }
-  }
+  integrateVelocitiesFromImpulses(_resetCommand);
 
   int cursor = 0;
   for (auto& skel : mSkeletons)
@@ -290,6 +271,30 @@ void World::step(bool _resetCommand)
 
   mTime += mTimeStep;
   mFrame++;
+}
+
+//==============================================================================
+void World::integrateVelocitiesFromImpulses(bool _resetCommand)
+{
+  // Compute velocity changes given constraint impulses
+  for (auto& skel : mSkeletons)
+  {
+    if (!skel->isMobile())
+      continue;
+
+    if (skel->isImpulseApplied())
+    {
+      skel->computeImpulseForwardDynamics();
+      skel->setImpulseApplied(false);
+    }
+
+    if (_resetCommand)
+    {
+      skel->clearInternalForces();
+      skel->clearExternalForces();
+      skel->resetCommands();
+    }
+  }
 }
 
 //==============================================================================

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -255,12 +255,6 @@ void World::step(bool _resetCommand)
       skel->setImpulseApplied(false);
     }
 
-    // <Nimble>: This is the original way integration happened, right after
-    // velocity updates
-    if (!mParallelVelocityAndPositionUpdates)
-      skel->integratePositions(mTimeStep);
-    // </Nimble>
-
     if (_resetCommand)
     {
       skel->clearInternalForces();
@@ -269,22 +263,30 @@ void World::step(bool _resetCommand)
     }
   }
 
-  // <Nimble>: This is an easier way to compute gradients for. We update p_t+1
-  // using v_t, instead of v_t+1
-  if (mParallelVelocityAndPositionUpdates)
+  int cursor = 0;
+  for (auto& skel : mSkeletons)
   {
-    int cursor = 0;
-    for (auto& skel : mSkeletons)
+    if (mParallelVelocityAndPositionUpdates)
     {
+      // <Nimble>: This is an easier way to compute gradients for. We update
+      // p_t+1 using v_t, instead of v_t+1
       int dofs = skel->getNumDofs();
       skel->setPositions(skel->integratePositionsExplicit(
           skel->getPositions(),
           initialVelocity.segment(cursor, dofs),
           mTimeStep));
       cursor += dofs;
+      // </Nimble>: Integrate positions before velocity changes, instead of
+      // after
+    }
+    else
+    {
+      // <Nimble>: This is the original way integration happened, right after
+      // velocity updates
+      skel->integratePositions(mTimeStep);
+      // </Nimble>
     }
   }
-  // </Nimble>: Integrate positions before velocity changes, instead of after
 
   mTime += mTimeStep;
   mFrame++;

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -243,31 +243,7 @@ void World::step(bool _resetCommand)
       mFallbackConstraintForceMixingConstant);
   mConstraintSolver->solve();
   integrateVelocitiesFromImpulses(_resetCommand);
-
-  int cursor = 0;
-  for (auto& skel : mSkeletons)
-  {
-    if (mParallelVelocityAndPositionUpdates)
-    {
-      // <Nimble>: This is an easier way to compute gradients for. We update
-      // p_t+1 using v_t, instead of v_t+1
-      int dofs = skel->getNumDofs();
-      skel->setPositions(skel->integratePositionsExplicit(
-          skel->getPositions(),
-          initialVelocity.segment(cursor, dofs),
-          mTimeStep));
-      cursor += dofs;
-      // </Nimble>: Integrate positions before velocity changes, instead of
-      // after
-    }
-    else
-    {
-      // <Nimble>: This is the original way integration happened, right after
-      // velocity updates
-      skel->integratePositions(mTimeStep);
-      // </Nimble>
-    }
-  }
+  integratePositions(initialVelocity);
 
   mTime += mTimeStep;
   mFrame++;
@@ -293,6 +269,35 @@ void World::integrateVelocitiesFromImpulses(bool _resetCommand)
       skel->clearInternalForces();
       skel->clearExternalForces();
       skel->resetCommands();
+    }
+  }
+}
+
+//==============================================================================
+void World::integratePositions(Eigen::VectorXs initialVelocity)
+{
+  int cursor = 0;
+  for (auto& skel : mSkeletons)
+  {
+    if (mParallelVelocityAndPositionUpdates)
+    {
+      // <Nimble>: This is an easier way to compute gradients for. We update
+      // p_t+1 using v_t, instead of v_t+1
+      int dofs = skel->getNumDofs();
+      skel->setPositions(skel->integratePositionsExplicit(
+          skel->getPositions(),
+          initialVelocity.segment(cursor, dofs),
+          mTimeStep));
+      cursor += dofs;
+      // </Nimble>: Integrate positions before velocity changes, instead of
+      // after
+    }
+    else
+    {
+      // <Nimble>: This is the original way integration happened, right after
+      // velocity updates
+      skel->integratePositions(mTimeStep);
+      // </Nimble>
     }
   }
 }

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -480,6 +480,9 @@ public:
   /// Integrate velocities given impulses.
   void integrateVelocitiesFromImpulses(bool _resetCommand);
 
+  /// Integrate positions.
+  void integratePositions(Eigen::VectorXs initialVelocity);
+
   /// Set current time
   void setTime(s_t _time);
 

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -478,7 +478,7 @@ public:
   void integrateVelocities();
 
   /// Integrate velocities given impulses.
-  void integrateVelocitiesFromImpulses(bool _resetCommand);
+  void integrateVelocitiesFromImpulses(bool _resetCommand = true);
 
   /// Integrate positions.
   void integratePositions(Eigen::VectorXs initialVelocity);

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -474,7 +474,11 @@ public:
   /// command after simulation step.
   void step(bool _resetCommand = true);
 
+  /// Integrate non-constraint forces.
   void integrateVelocities();
+
+  /// Integrate velocities given impulses.
+  void integrateVelocitiesFromImpulses(bool _resetCommand);
 
   /// Set current time
   void setTime(s_t _time);

--- a/python/_nimblephysics/simulation/World.cpp
+++ b/python/_nimblephysics/simulation/World.cpp
@@ -268,7 +268,7 @@ void World(py::module& m)
           +[](dart::simulation::World* self, bool _resetCommand) -> void {
             return self->integrateVelocitiesFromImpulses(_resetCommand);
           },
-          ::py::arg("resetCommand"))
+          ::py::arg("resetCommand") = true)
       .def(
           "setTime",
           +[](dart::simulation::World* self, s_t _time) -> void {

--- a/python/_nimblephysics/simulation/World.cpp
+++ b/python/_nimblephysics/simulation/World.cpp
@@ -259,6 +259,17 @@ void World(py::module& m)
           },
           ::py::arg("resetCommand"))
       .def(
+          "integratePositions",
+          +[](dart::simulation::World* self, Eigen::VectorXs initialVelocity)
+              -> void { return self->integratePositions(initialVelocity); },
+          ::py::arg("initialVelocity"))
+      .def(
+          "integrateVelocitiesFromImpulses",
+          +[](dart::simulation::World* self, bool _resetCommand) -> void {
+            return self->integrateVelocitiesFromImpulses(_resetCommand);
+          },
+          ::py::arg("resetCommand"))
+      .def(
           "setTime",
           +[](dart::simulation::World* self, s_t _time) -> void {
             return self->setTime(_time);
@@ -314,9 +325,8 @@ void World(py::module& m)
           })
       .def(
           "getMasses",
-          +[](dart::simulation::World* self) -> Eigen::VectorXs {
-            return self->getMasses();
-          })
+          +[](dart::simulation::World* self)
+              -> Eigen::VectorXs { return self->getMasses(); })
       .def(
           "getControlForceUpperLimits",
           +[](dart::simulation::World* self) -> Eigen::VectorXs {

--- a/python/new_examples/constraint_callback.py
+++ b/python/new_examples/constraint_callback.py
@@ -30,6 +30,10 @@ def main():
     state = torch.tensor(world.getState())
     action = torch.zeros((world.getNumDofs()))
     solver = world.getConstraintSolver()
+
+    # Try the default arg
+    world.integrateVelocitiesFromImpulses()
+
     callbacks = [
         None,  # Use default LCP, don't replace
         dummy_callback,  # Replace with dummy function


### PR DESCRIPTION
Round 3 Review
- Add default arg for `integrateVelocitiesFromImpulses`.

Round 2 Review
- Add python bindings.

Round 1 Review
- Separate position integration from impulse velocity integration.
- Create functions for velocity (impulse) integration and position integration.