### PR TITLE
return `LcpResult` in `solveLcp`

### DIFF
--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -349,7 +349,7 @@ LcpInputs BoxedLcpConstraintSolver::buildLcpInputs(ConstrainedGroup& group)
 }
 
 //==============================================================================
-std::vector<s_t*> BoxedLcpConstraintSolver::solveLcp(
+LcpResult BoxedLcpConstraintSolver::solveLcp(
     LcpInputs lcpInputs, ConstrainedGroup& group)
 {
   const std::size_t numConstraints = group.getNumConstraints();
@@ -785,7 +785,9 @@ std::vector<s_t*> BoxedLcpConstraintSolver::solveLcp(
     }
     constraintImpulses.push_back(mX.data() + mOffset[i]);
   }
-  return constraintImpulses;
+  LcpResult result;
+  result.impulses = constraintImpulses;
+  return result;
 }
 
 //==============================================================================
@@ -793,7 +795,8 @@ std::vector<s_t*> BoxedLcpConstraintSolver::solveConstrainedGroup(
     ConstrainedGroup& group)
 {
   LcpInputs lcpInputs = buildLcpInputs(group);
-  return solveLcp(lcpInputs, group);
+  LcpResult result = solveLcp(lcpInputs, group);
+  return result.impulses;
 }
 
 //==============================================================================

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -40,6 +40,12 @@
 namespace dart {
 namespace constraint {
 
+struct LcpResult
+{
+  // This is the solution to the LCP.
+  std::vector<s_t*> impulses;
+};
+
 class BoxedLcpConstraintSolver : public ConstraintSolver
 {
 public:
@@ -120,7 +126,7 @@ public:
   LcpInputs buildLcpInputs(ConstrainedGroup& group);
 
   /// Setup and solve an LCP to enforce the constraints on the ConstrainedGroup.
-  std::vector<s_t*> solveLcp(LcpInputs lcpInputs, ConstrainedGroup& group);
+  LcpResult solveLcp(LcpInputs lcpInputs, ConstrainedGroup& group);
 
 protected:
   /// Boxed LCP solver

--- a/python/_nimblephysics/constraint/BoxedLcpConstraintSolver.cpp
+++ b/python/_nimblephysics/constraint/BoxedLcpConstraintSolver.cpp
@@ -88,9 +88,13 @@ void BoxedLcpConstraintSolver(py::module& m)
           "solveLcp",
           +[](dart::constraint::BoxedLcpConstraintSolver* self,
               dart::constraint::LcpInputs lcpInputs,
-              dart::constraint::ConstrainedGroup& group) -> std::vector<s_t*> {
+              dart::constraint::ConstrainedGroup& group)
+              -> dart::constraint::LcpResult {
             return self->solveLcp(lcpInputs, group);
           });
+  ::py::class_<dart::constraint::LcpResult>(m, "LcpResult")
+      .def(::py::init<>())
+      .def_readwrite("impulses", &constraint::LcpResult::impulses);
 }
 
 } // namespace python


### PR DESCRIPTION
Defines a struct that `solveLcp()` returns called `LcpResult`, and stores all useful information from `solveLcp()` inside of this struct.