### PR TITLE
Add marker placer to scaling setup to avoid OpenSim error message

### DIFF
--- a/dart/biomechanics/OpenSimParser.cpp
+++ b/dart/biomechanics/OpenSimParser.cpp
@@ -401,6 +401,9 @@ void OpenSimParser::saveOsimScalingXMLFile(
         <!--Name of file to write containing the scale factors that were applied to the unscaled model (optional).-->
         <output_scale_file>Unassigned</output_scale_file>
       </ModelScaler>
+      <MarkerPlacer>
+        <apply>false</apply>
+      </MarkerPlacer>
       </ScaleTool>
   </OpenSimDocument>
 


### PR DESCRIPTION
With the existing scaling setup, you get this error message at run time:
> [error] Marker placement parameters disabled (apply is false) or not set. No markers have been moved.

Effectively, this is not a problem (you still get a model as ouput) but I believe the scaling tool is expecting something about the marker placer, which is why an error is thrown.

If you add the couple of lines I added, you get the exact same model as output, but with no OpenSim error message.

Bottom line: there was no bug, but the error message might confuse users. Should be fixed.